### PR TITLE
Add ToDictionary() and other things

### DIFF
--- a/OData.QueryBuilder.sln
+++ b/OData.QueryBuilder.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28307.705
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29230.47
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{FA1582AB-A13D-44A4-A46D-2DAE1111A2BB}"
 EndProject

--- a/src/OData.QueryBuilder/Extensions/ExpressionExtension.cs
+++ b/src/OData.QueryBuilder/Extensions/ExpressionExtension.cs
@@ -289,6 +289,14 @@ namespace OData.QueryBuilder.Extensions
                         }
                     }
 
+                    if (methodName == "ToString")
+                    {
+                        var member = (methodCallExpression.Object as MemberExpression);
+
+                        return member == null ? string.Concat("'", methodCallExpression.Object.ToString().Replace("{", "").Replace("}", ""), "'") :
+                            !string.IsNullOrEmpty(member?.Member?.Name) ? member.Member.Name.Replace(".", "/") : "";
+                    }
+
                     return string.Empty;
 
                 case NewExpression newExpression:

--- a/src/OData.QueryBuilder/Parameters/IODataQueryParameter.cs
+++ b/src/OData.QueryBuilder/Parameters/IODataQueryParameter.cs
@@ -1,9 +1,12 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace OData.QueryBuilder.Parameters
 {
     public interface IODataQueryParameter
     {
         Uri ToUri();
+
+        Dictionary<string, string> ToDicionary();
     }
 }

--- a/src/OData.QueryBuilder/Parameters/IODataQueryParameter.cs
+++ b/src/OData.QueryBuilder/Parameters/IODataQueryParameter.cs
@@ -7,6 +7,6 @@ namespace OData.QueryBuilder.Parameters
     {
         Uri ToUri();
 
-        Dictionary<string, string> ToDicionary();
+        Dictionary<string, string> ToDictionary();
     }
 }

--- a/src/OData.QueryBuilder/Parameters/ODataQueryParameterKey.cs
+++ b/src/OData.QueryBuilder/Parameters/ODataQueryParameterKey.cs
@@ -55,6 +55,6 @@ namespace OData.QueryBuilder.Parameters
 
         public Uri ToUri() => new Uri(_queryBuilder.ToString().TrimEnd('&'));
 
-        public Dictionary<string, string> ToDicionary() => _dicionaryBuilder;
+        public Dictionary<string, string> ToDictionary() => _dicionaryBuilder;
     }
 }

--- a/src/OData.QueryBuilder/Parameters/ODataQueryParameterKey.cs
+++ b/src/OData.QueryBuilder/Parameters/ODataQueryParameterKey.cs
@@ -1,6 +1,7 @@
 ﻿using OData.QueryBuilder.Builders.Nested;
 using OData.QueryBuilder.Extensions;
 using System;
+using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Text;
 
@@ -10,14 +11,22 @@ namespace OData.QueryBuilder.Parameters
     {
         private readonly StringBuilder _queryBuilder;
 
-        public ODataQueryParameterKey(StringBuilder queryBuilder) =>
+        private readonly Dictionary<string, string> _dicionaryBuilder;
+
+        //public ODataQueryParameterKey(StringBuilder queryBuilder) => _queryBuilder = queryBuilder;
+
+        public ODataQueryParameterKey(StringBuilder queryBuilder)
+        {
             _queryBuilder = queryBuilder;
+            _dicionaryBuilder = new Dictionary<string, string>();
+        }
 
         public IODataQueryParameterKey<TEntity> Expand(Expression<Func<TEntity, object>> entityExpand)
         {
             var entityExpandQuery = entityExpand.Body.ToODataQuery(string.Empty);
 
             _queryBuilder.Append($"$expand={entityExpandQuery}&");
+            _dicionaryBuilder.Add("$expand", entityExpandQuery);
 
             return this;
         }
@@ -29,6 +38,7 @@ namespace OData.QueryBuilder.Parameters
             entityExpandNested(odataQueryNestedBuilder);
 
             _queryBuilder.Append($"$expand={odataQueryNestedBuilder.Query}&");
+            _dicionaryBuilder.Add("$expand", odataQueryNestedBuilder.Query);
 
             return this;
         }
@@ -38,10 +48,13 @@ namespace OData.QueryBuilder.Parameters
             var entitySelectQuery = entitySelect.Body.ToODataQuery(string.Empty);
 
             _queryBuilder.Append($"$select={entitySelectQuery}&");
+            _dicionaryBuilder.Add("$select", entitySelectQuery);
 
             return this;
         }
 
         public Uri ToUri() => new Uri(_queryBuilder.ToString().TrimEnd('&'));
+
+        public Dictionary<string, string> ToDicionary() => _dicionaryBuilder;
     }
 }

--- a/src/OData.QueryBuilder/Parameters/ODataQueryParameterList.cs
+++ b/src/OData.QueryBuilder/Parameters/ODataQueryParameterList.cs
@@ -107,6 +107,6 @@ namespace OData.QueryBuilder.Parameters
 
         public Uri ToUri() => new Uri(_queryBuilder.ToString().TrimEnd('&'));
 
-        public Dictionary<string, string> ToDicionary() => _dicionaryBuilder;
+        public Dictionary<string, string> ToDictionary() => _dicionaryBuilder;
     }
 }

--- a/src/OData.QueryBuilder/Parameters/ODataQueryParameterList.cs
+++ b/src/OData.QueryBuilder/Parameters/ODataQueryParameterList.cs
@@ -1,6 +1,7 @@
 ﻿using OData.QueryBuilder.Builders.Nested;
 using OData.QueryBuilder.Extensions;
 using System;
+using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Text;
 
@@ -10,14 +11,20 @@ namespace OData.QueryBuilder.Parameters
     {
         private readonly StringBuilder _queryBuilder;
 
-        public ODataQueryParameterList(StringBuilder queryBuilder) =>
+        private readonly Dictionary<string, string> _dicionaryBuilder;
+
+        public ODataQueryParameterList(StringBuilder queryBuilder)
+        {
             _queryBuilder = queryBuilder;
+            _dicionaryBuilder = new Dictionary<string, string>();
+        }
 
         public IODataQueryParameterList<TEntity> Filter(Expression<Func<TEntity, bool>> entityFilter)
         {
             var entityFilterQuery = entityFilter.Body.ToODataQuery(string.Empty);
 
             _queryBuilder.Append($"$filter={entityFilterQuery}&");
+            _dicionaryBuilder.Add("$filter", entityFilterQuery);
 
             return this;
         }
@@ -27,6 +34,7 @@ namespace OData.QueryBuilder.Parameters
             var entityExpandQuery = entityExpand.Body.ToODataQuery(string.Empty);
 
             _queryBuilder.Append($"$expand={entityExpandQuery}&");
+            _dicionaryBuilder.Add("$expand", entityExpandQuery);
 
             return this;
         }
@@ -38,6 +46,7 @@ namespace OData.QueryBuilder.Parameters
             entityExpandNested(odataQueryNestedBuilder);
 
             _queryBuilder.Append($"$expand={odataQueryNestedBuilder.Query}&");
+            _dicionaryBuilder.Add("$expand", odataQueryNestedBuilder.Query);
 
             return this;
         }
@@ -47,6 +56,7 @@ namespace OData.QueryBuilder.Parameters
             var entitySelectQuery = entitySelect.Body.ToODataQuery(string.Empty);
 
             _queryBuilder.Append($"$select={entitySelectQuery}&");
+            _dicionaryBuilder.Add("$select", entitySelectQuery);
 
             return this;
         }
@@ -56,6 +66,7 @@ namespace OData.QueryBuilder.Parameters
             var entityOrderByQuery = entityOrderBy.Body.ToODataQuery(string.Empty);
 
             _queryBuilder.Append($"$orderby={entityOrderByQuery} asc&");
+            _dicionaryBuilder.Add("$orderby", entityOrderByQuery + " asc");
 
             return this;
         }
@@ -65,6 +76,7 @@ namespace OData.QueryBuilder.Parameters
             var entityOrderByDescendingQuery = entityOrderByDescending.Body.ToODataQuery(string.Empty);
 
             _queryBuilder.Append($"$orderby={entityOrderByDescendingQuery} desc&");
+            _dicionaryBuilder.Add("$orderby", entityOrderByDescendingQuery + " desc");
 
             return this;
         }
@@ -72,6 +84,7 @@ namespace OData.QueryBuilder.Parameters
         public IODataQueryParameterList<TEntity> Skip(int number)
         {
             _queryBuilder.Append($"$skip={number}&");
+            _dicionaryBuilder.Add("$skip", number.ToString());
 
             return this;
         }
@@ -79,6 +92,7 @@ namespace OData.QueryBuilder.Parameters
         public IODataQueryParameterList<TEntity> Top(int number)
         {
             _queryBuilder.Append($"$top={number}&");
+            _dicionaryBuilder.Add("$top", number.ToString());
 
             return this;
         }
@@ -86,10 +100,13 @@ namespace OData.QueryBuilder.Parameters
         public IODataQueryParameterList<TEntity> Count(bool value = true)
         {
             _queryBuilder.Append($"$count={value.ToString().ToLower()}&");
+            _dicionaryBuilder.Add("$count", value.ToString().ToLower());
 
             return this;
         }
 
         public Uri ToUri() => new Uri(_queryBuilder.ToString().TrimEnd('&'));
+
+        public Dictionary<string, string> ToDicionary() => _dicionaryBuilder;
     }
 }

--- a/test/OData.QueryBuilder.Test/Fakes/ODataTypeEntity.cs
+++ b/test/OData.QueryBuilder.Test/Fakes/ODataTypeEntity.cs
@@ -27,6 +27,17 @@ namespace OData.QueryBuilder.Test.Fakes
         public ODataKindEntity ODataKind { get; set; }
 
         public ODataKindEntity ODataKindNew { get; set; }
+
+        public Color Color { get; set; }
+    }
+
+    public enum Color
+    {
+        Green,
+        Red,
+        Blue,
+        Yellow,
+        Black
     }
 }
 

--- a/test/OData.QueryBuilder.Test/ODataQueryBuilderByKeyTest.cs
+++ b/test/OData.QueryBuilder.Test/ODataQueryBuilderByKeyTest.cs
@@ -109,7 +109,7 @@ namespace OData.QueryBuilder.Test
                 .For<ODataTypeEntity>(s => s.ODataType)
                 .ByKey("223123123")
                 .Expand(s => s.ODataKind)
-                .ToDicionary();
+                .ToDictionary();
         }
     }
 }

--- a/test/OData.QueryBuilder.Test/ODataQueryBuilderByKeyTest.cs
+++ b/test/OData.QueryBuilder.Test/ODataQueryBuilderByKeyTest.cs
@@ -101,5 +101,15 @@ namespace OData.QueryBuilder.Test
 
             uri.OriginalString.Should().Be("http://mock/odata/ODataType(223123123)?$expand=ODataKind($filter=IdKind eq 1;$select=IdKind)&$select=IdType,Sum");
         }
+
+        [Fact(DisplayName = "(ODataQueryBuilderKey) ToDicionary => Success")]
+        public void ToDicionaryTest()
+        {
+            var uri = _odataQueryBuilder
+                .For<ODataTypeEntity>(s => s.ODataType)
+                .ByKey("223123123")
+                .Expand(s => s.ODataKind)
+                .ToDicionary();
+        }
     }
 }

--- a/test/OData.QueryBuilder.Test/ODataQueryBuilderByListTest.cs
+++ b/test/OData.QueryBuilder.Test/ODataQueryBuilderByListTest.cs
@@ -317,5 +317,23 @@ namespace OData.QueryBuilder.Test
 
             uri.OriginalString.Should().Be("http://mock/odata/ODataType?$filter=IsActive and not IsOpen");
         }
+
+        [Fact(DisplayName = "(ODataQueryBuilderList) ToDicionaryTest")]
+        public void ToDicionaryTest()
+        {
+            var constValue = false;
+            var newObject = new ODataTypeEntity { IsOpen = false };
+
+            var uri = _odataQueryBuilder
+            .For<ODataTypeEntity>(s => s.ODataType)
+            .ByList()
+            .Filter(s => s.IsActive
+                && s.IsOpen == constValue
+                && s.IsOpen == true
+                && s.ODataKind.ODataCode.IdActive == newObject.IsOpen)
+            .Skip(1)
+            .Top(10)
+            .ToDicionary();
+        }
     }
 }

--- a/test/OData.QueryBuilder.Test/ODataQueryBuilderByListTest.cs
+++ b/test/OData.QueryBuilder.Test/ODataQueryBuilderByListTest.cs
@@ -342,7 +342,7 @@ namespace OData.QueryBuilder.Test
                 && s.ODataKind.ODataCode.IdActive == newObject.IsOpen)
             .Skip(1)
             .Top(10)
-            .ToDicionary();
+            .ToDictionary();
         }
     }
 }

--- a/test/OData.QueryBuilder.Test/ODataQueryBuilderByListTest.cs
+++ b/test/OData.QueryBuilder.Test/ODataQueryBuilderByListTest.cs
@@ -344,5 +344,17 @@ namespace OData.QueryBuilder.Test
             .Top(10)
             .ToDictionary();
         }
+
+        [Fact(DisplayName = "(ODataQueryBuilderList) FilterEnum")]
+        public void FilterEnumTest()
+        {
+            var uri = _odataQueryBuilder
+            .For<ODataTypeEntity>(s => s.ODataType)
+            .ByList()
+            .Filter(s => s.Color.ToString() == Color.Blue.ToString())
+            .Skip(1)
+            .Top(10)
+            .ToUri();
+        }
     }
 }

--- a/test/OData.QueryBuilder.Test/ODataQueryBuilderByListTest.cs
+++ b/test/OData.QueryBuilder.Test/ODataQueryBuilderByListTest.cs
@@ -169,13 +169,12 @@ namespace OData.QueryBuilder.Test
                     )
                 .Select(s => new { s.ODataKind, s.Sum })
                 .OrderBy(s => new { s.IdType })
-                .OrderByDescending(s => s.IdType)
                 .Skip(1)
                 .Top(1)
                 .Count()
                 .ToUri();
 
-            uri.OriginalString.Should().Be($"http://mock/odata/ODataType?$expand=ODataKind&$filter=IdType lt 2 and ODataKind/ODataCode/IdCode ge 3 or IdType eq 5 and IdRule ne null and IdRule eq null&$select=ODataKind,Sum&$orderby=IdType asc&$orderby=IdType desc&$skip=1&$top=1&$count=true");
+            uri.OriginalString.Should().Be($"http://mock/odata/ODataType?$expand=ODataKind&$filter=IdType lt 2 and ODataKind/ODataCode/IdCode ge 3 or IdType eq 5 and IdRule ne null and IdRule eq null&$select=ODataKind,Sum&$orderby=IdType asc&$skip=1&$top=1&$count=true");
         }
 
         [Fact(DisplayName = "(ODataQueryBuilderList) Function Date => Success")]

--- a/test/OData.QueryBuilder.Test/ODataQueryBuilderByListTest.cs
+++ b/test/OData.QueryBuilder.Test/ODataQueryBuilderByListTest.cs
@@ -228,6 +228,16 @@ namespace OData.QueryBuilder.Test
             uri.OriginalString.Should().Be("http://mock/odata/ODataType?$filter=ODataKind/ODataCode/Code in ('123','512') and ODataKind/ODataCode/Code in ('123','512') and IdType in (123,512) and IdType in (123,512) and IdRule in (123,512) and IdRule in (123,512) and ODataKind/IdKind in (123,512) and ODataKind/ODataCode/IdCode in (123,512)");
         }
 
+        [Fact(DisplayName = "(ODataQueryBuilderList) Contains Simple Test => Success")]
+        public void ODataQueryBuilderList_Test_ContainsSimple()
+        {
+            var uri = _odataQueryBuilder
+                .For<ODataTypeEntity>(s => s.ODataType)
+                .ByList()
+                .Filter(s => s.ODataKind.ODataCode.Code.Contains("0") || s.ODataKindNew.ODataCode.Code.Contains("55"))
+                .ToUri();
+        }
+
         [Fact(DisplayName = "(ODataQueryBuilderList) Operator IN empty => Success")]
         public void ODataQueryBuilderList_Operator_In_Empty_Success()
         {


### PR DESCRIPTION
### **Add support ToDictionary():**

In some cases it is necessary to send a dictionary to url.

eg:
```
var odataBuilder = new ODataQueryBuilder<Core.Data.DataModels.Booking>(ODataParameter.FakeUri)
                    .For<Core.Data.DataModels.Booking>(x => x)
                    .ByList()
                    .Top(top)
                    .Skip(skip)
                    .Filter(x => x.DataItem.Description.Title == "Test")
                    .OrderBy(x => x.CreatedAt);
```
                    
var **dic** = odataBuilder.**ToDicionary()**;

The result is:
![image](https://user-images.githubusercontent.com/5353685/64996728-20a6e700-d8b5-11e9-970e-8b332256023f.png)


Send url with dicionary:

`return await ServiceClient.InvokeApiAsync<List<Core.Data.DataModels.Booking>>("Booking/GetAllByDataStoreId", HttpMethod.Get, **dic**);`

This modification does not change the ToUrl() :)

### **Add support Contains() text:**

eg:
```
var uri = _odataQueryBuilder
                .For<ODataTypeEntity>(s => s.ODataType)
                .ByList()
                .Filter(s => s.ODataKind.ODataCode.Code.Contains("0") || s.ODataKindNew.ODataCode.Code.Contains("55"))
                .ToUri();
```
Url result:
`http://mock/odata/ODataType?$filter=substringof('0',toupper(ODataKind/ODataCode/Code)) or substringof('55',toupper(ODataKindNew/ODataCode/Code))`

### **Add support enum ToString() compare:**

eg:
```
 var uri = _odataQueryBuilder
            .For<ODataTypeEntity>(s => s.ODataType)
            .ByList()
            .Filter(s => **s.Color.ToString() == Color.Blue.ToString()**)
            .Skip(1)
            .Top(10)
            .ToUri();
```
Url result:
`http://mock/odata/ODataType?$filter=Color eq 'Blue'&$skip=1&$top=10`