### PR TITLE
Fixed an issue where ampersands in string values were not escaped properly

### DIFF
--- a/src/OData.QueryBuilder/Extensions/ReflectionExtensions.cs
+++ b/src/OData.QueryBuilder/Extensions/ReflectionExtensions.cs
@@ -29,31 +29,42 @@ namespace OData.QueryBuilder.Extensions
 
         public static string ConvertToString(object @object)
         {
+            string toReturn;
+
             switch (@object)
             {
                 case null:
                     return default;
                 case string @string:
-                    return $"'{@string}'";
+                    toReturn = $"'{@string}'";
+                    break;
                 case bool @bool:
-                    return $"{@bool}".ToLower();
+                    toReturn = $"{@bool}".ToLower();
+                    break;
                 case int @int:
-                    return $"{@int}";
+                    toReturn = $"{@int}";
+                    break;
                 case DateTime dateTime:
-                    return $"{dateTime:s}Z";
+                    toReturn = $"{dateTime:s}Z";
+                    break;
                 case DateTimeOffset dateTimeOffset:
-                    return $"{dateTimeOffset:s}Z";
+                    toReturn = $"{dateTimeOffset:s}Z";
+                    break;
                 case IEnumerable<int> intValues:
                     var intValuesString = string.Join(QuerySeparators.CommaString, intValues);
 
-                    return !string.IsNullOrEmpty(intValuesString) ? intValuesString : string.Empty;
+                    toReturn = !string.IsNullOrEmpty(intValuesString) ? intValuesString : string.Empty;
+                    break;
                 case IEnumerable<string> stringValues:
                     var stringValuesString = string.Join($"'{QuerySeparators.CommaString}'", stringValues);
 
-                    return !string.IsNullOrEmpty(stringValuesString) ? $"'{stringValuesString}'" : string.Empty;
+                    toReturn = !string.IsNullOrEmpty(stringValuesString) ? $"'{stringValuesString}'" : string.Empty;
+                    break;
                 default:
                     return $"{@object}";
             }
+
+            return toReturn.Replace("&", "%26");
         }
     }
 }

--- a/test/OData.QueryBuilder.Test/ODataQueryOptionListTest.cs
+++ b/test/OData.QueryBuilder.Test/ODataQueryOptionListTest.cs
@@ -196,6 +196,19 @@ namespace OData.QueryBuilder.Test
             uri.OriginalString.Should().Be("http://mock/odata/ODataType?$filter=ODataKind/ODataCode/Code eq '3' or ODataKind/ODataCode/Code eq '5' and ODataKind/ODataCode/Code eq 'testCode'");
         }
 
+        [Fact(DisplayName = "Filter const string with ampersand => Success")]
+        public void ODataQueryBuilderList_Filter_Escaped_Ampersand_String_Success()
+        {
+            var constValue = "3 & 4";
+            var uri = _odataQueryBuilderDefault
+                .For<ODataTypeEntity>(s => s.ODataType)
+                .ByList()
+                .Filter(s => s.ODataKind.ODataCode.Code == constValue)
+                .ToUri();
+
+            uri.OriginalString.Should().Be("http://mock/odata/ODataType?$filter=ODataKind/ODataCode/Code eq '3 %26 4'");
+        }
+
         [Fact(DisplayName = "Filter  operators All/Any => Success")]
         public void ODataQueryBuilderList_Filter_All_Any_Success()
         {


### PR DESCRIPTION
Essentially ran into the issue described in [this post](https://powerusers.microsoft.com/t5/Using-Flows/Unable-to-Properly-Parse-quot-amp-quot-ampersand-within-odata/td-p/283086) while using this library. Was able to fix the issue by escaping "&" to "%26". I don't believe any other characters should require escaping. 