### PR TITLE
Add support for dynamic properties to queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ Library for creating complex OData queries (OData version 4.01) based on data mo
     * type
         * [`cast`](#cast)
   * sorting by several fields with indication of direction
-
+  * dynamic properties
+    
 ## Installation
 To install `OData.QueryBuilder` from `Visual Studio`, find `OData.QueryBuilder` in the `NuGet` package manager user interface or enter the following command in the package manager console:
 ```
@@ -382,6 +383,20 @@ var strings = new string[] {
     new Dictionary<string, string>() { { @"\", "%5C" } })))
 ```
 > $filter=ODataKind/ODataCode/Code in ('test%5C%5CYUYYUT','test1%5C%5CYUYY123')
+
+## Using dynamic properties
+
+For use-cases where a property which is used for queries needs to be dynamically resolved (eg. the user chooses the property name to filter on)
+a special method `ODataProperty.FromPath<TProperty>()` can be invoked in the query expressions:
+
+```csharp
+...
+.Filter(s => ODataProperty.FromPath<int>("IdRule") == 3))
+```
+
+Note that the generic type argument `TProperty` needs to match the type of the dynamically
+resolved property in the OData model.
+
 
 ## Suppress exceptions
 

--- a/src/OData.QueryBuilder/Conventions/AddressingEntities/Query/Expand/ODataQueryExpand.cs
+++ b/src/OData.QueryBuilder/Conventions/AddressingEntities/Query/Expand/ODataQueryExpand.cs
@@ -21,7 +21,7 @@ namespace OData.QueryBuilder.Conventions.AddressingEntities.Query.Expand
         }
         public IODataQueryExpand<TEntity> Expand(Expression<Func<TEntity, object>> expandNested)
         {
-            var query = new ODataOptionExpandExpressionVisitor().ToQuery(expandNested.Body);
+            var query = new ODataOptionExpandExpressionVisitor().ToQuery(expandNested);
 
             _stringBuilder.Append($"{ODataOptionNames.Expand}{QuerySeparators.EqualSign}{query}{QuerySeparators.Nested}");
 
@@ -41,28 +41,28 @@ namespace OData.QueryBuilder.Conventions.AddressingEntities.Query.Expand
 
         public IODataQueryExpand<TEntity> Filter(Expression<Func<TEntity, bool>> filterNested, bool useParenthesis = false)
         {
-            var query = new ODataOptionFilterExpressionVisitor(_odataQueryBuilderOptions).ToQuery(filterNested.Body, useParenthesis);
+            var query = new ODataOptionFilterExpressionVisitor(_odataQueryBuilderOptions).ToQuery(filterNested, useParenthesis);
 
             return Filter(query);
         }
 
         public IODataQueryExpand<TEntity> Filter(Expression<Func<TEntity, IODataFunction, bool>> filterNested, bool useParenthesis = false)
         {
-            var query = new ODataOptionFilterExpressionVisitor(_odataQueryBuilderOptions).ToQuery(filterNested.Body, useParenthesis);
+            var query = new ODataOptionFilterExpressionVisitor(_odataQueryBuilderOptions).ToQuery(filterNested, useParenthesis);
 
             return Filter(query);
         }
 
         public IODataQueryExpand<TEntity> Filter(Expression<Func<TEntity, IODataFunction, IODataOperator, bool>> filterNested, bool useParenthesis = false)
         {
-            var query = new ODataOptionFilterExpressionVisitor(_odataQueryBuilderOptions).ToQuery(filterNested.Body, useParenthesis);
+            var query = new ODataOptionFilterExpressionVisitor(_odataQueryBuilderOptions).ToQuery(filterNested, useParenthesis);
 
             return Filter(query);
         }
 
         public IODataQueryExpand<TEntity> OrderBy(Expression<Func<TEntity, object>> orderByNested)
         {
-            var query = new ODataOptionOrderByExpressionVisitor().ToQuery(orderByNested.Body);
+            var query = new ODataOptionOrderByExpressionVisitor().ToQuery(orderByNested);
 
             _stringBuilder.Append($"{ODataOptionNames.OrderBy}{QuerySeparators.EqualSign}{query} {QuerySorts.Asc}{QuerySeparators.Nested}");
 
@@ -71,7 +71,7 @@ namespace OData.QueryBuilder.Conventions.AddressingEntities.Query.Expand
 
         public IODataQueryExpand<TEntity> OrderBy(Expression<Func<TEntity, ISortFunction, object>> orderByNested)
         {
-            var query = new ODataOptionOrderByExpressionVisitor().ToQuery(orderByNested.Body);
+            var query = new ODataOptionOrderByExpressionVisitor().ToQuery(orderByNested);
 
             _stringBuilder.Append($"{ODataOptionNames.OrderBy}{QuerySeparators.EqualSign}{query}{QuerySeparators.Nested}");
 
@@ -80,7 +80,7 @@ namespace OData.QueryBuilder.Conventions.AddressingEntities.Query.Expand
 
         public IODataQueryExpand<TEntity> OrderByDescending(Expression<Func<TEntity, object>> orderByDescendingNested)
         {
-            var query = new ODataOptionOrderByExpressionVisitor().ToQuery(orderByDescendingNested.Body);
+            var query = new ODataOptionOrderByExpressionVisitor().ToQuery(orderByDescendingNested);
 
             _stringBuilder.Append($"{ODataOptionNames.OrderBy}{QuerySeparators.EqualSign}{query} {QuerySorts.Desc}{QuerySeparators.Nested}");
 
@@ -89,7 +89,7 @@ namespace OData.QueryBuilder.Conventions.AddressingEntities.Query.Expand
 
         public IODataQueryExpand<TEntity> Select(Expression<Func<TEntity, object>> selectNested)
         {
-            var query = new ODataOptionSelectExpressionVisitor().ToQuery(selectNested.Body);
+            var query = new ODataOptionSelectExpressionVisitor().ToQuery(selectNested);
 
             _stringBuilder.Append($"{ODataOptionNames.Select}{QuerySeparators.EqualSign}{query}{QuerySeparators.Nested}");
 

--- a/src/OData.QueryBuilder/Conventions/AddressingEntities/Query/ODataQueryCollection.cs
+++ b/src/OData.QueryBuilder/Conventions/AddressingEntities/Query/ODataQueryCollection.cs
@@ -25,28 +25,28 @@ namespace OData.QueryBuilder.Conventions.AddressingEntities.Query
 
         public IODataQueryCollection<TEntity> Filter(Expression<Func<TEntity, bool>> filter, bool useParenthesis = false)
         {
-            var query = new ODataOptionFilterExpressionVisitor(_odataQueryBuilderOptions).ToQuery(filter.Body, useParenthesis);
+            var query = new ODataOptionFilterExpressionVisitor(_odataQueryBuilderOptions).ToQuery(filter, useParenthesis);
 
             return Filter(query);
         }
 
         public IODataQueryCollection<TEntity> Filter(Expression<Func<TEntity, IODataFunction, bool>> filter, bool useParenthesis = false)
         {
-            var query = new ODataOptionFilterExpressionVisitor(_odataQueryBuilderOptions).ToQuery(filter.Body, useParenthesis);
+            var query = new ODataOptionFilterExpressionVisitor(_odataQueryBuilderOptions).ToQuery(filter, useParenthesis);
 
             return Filter(query);
         }
 
         public IODataQueryCollection<TEntity> Filter(Expression<Func<TEntity, IODataFunction, IODataOperator, bool>> filter, bool useParenthesis = false)
         {
-            var query = new ODataOptionFilterExpressionVisitor(_odataQueryBuilderOptions).ToQuery(filter.Body, useParenthesis);
+            var query = new ODataOptionFilterExpressionVisitor(_odataQueryBuilderOptions).ToQuery(filter, useParenthesis);
 
             return Filter(query);
         }
 
         public IODataQueryCollection<TEntity> Expand(Expression<Func<TEntity, object>> expand)
         {
-            var query = new ODataOptionExpandExpressionVisitor().ToQuery(expand.Body);
+            var query = new ODataOptionExpandExpressionVisitor().ToQuery(expand);
 
             return Expand(query);
         }
@@ -62,7 +62,7 @@ namespace OData.QueryBuilder.Conventions.AddressingEntities.Query
 
         public IODataQueryCollection<TEntity> Select(Expression<Func<TEntity, object>> select)
         {
-            var query = new ODataOptionSelectExpressionVisitor().ToQuery(select.Body);
+            var query = new ODataOptionSelectExpressionVisitor().ToQuery(select);
 
             _stringBuilder.Append($"{ODataOptionNames.Select}{QuerySeparators.EqualSign}{query}{QuerySeparators.Main}");
 
@@ -71,7 +71,7 @@ namespace OData.QueryBuilder.Conventions.AddressingEntities.Query
 
         public IODataQueryCollection<TEntity> OrderBy(Expression<Func<TEntity, object>> orderBy)
         {
-            var query = new ODataOptionOrderByExpressionVisitor().ToQuery(orderBy.Body);
+            var query = new ODataOptionOrderByExpressionVisitor().ToQuery(orderBy);
 
             _stringBuilder.Append($"{ODataOptionNames.OrderBy}{QuerySeparators.EqualSign}{query} {QuerySorts.Asc}{QuerySeparators.Main}");
 
@@ -80,7 +80,7 @@ namespace OData.QueryBuilder.Conventions.AddressingEntities.Query
 
         public IODataQueryCollection<TEntity> OrderBy(Expression<Func<TEntity, ISortFunction, object>> orderBy)
         {
-            var query = new ODataOptionOrderByExpressionVisitor().ToQuery(orderBy.Body);
+            var query = new ODataOptionOrderByExpressionVisitor().ToQuery(orderBy);
 
             _stringBuilder.Append($"{ODataOptionNames.OrderBy}{QuerySeparators.EqualSign}{query}{QuerySeparators.Main}");
 
@@ -89,7 +89,7 @@ namespace OData.QueryBuilder.Conventions.AddressingEntities.Query
 
         public IODataQueryCollection<TEntity> OrderByDescending(Expression<Func<TEntity, object>> orderByDescending)
         {
-            var query = new ODataOptionOrderByExpressionVisitor().ToQuery(orderByDescending.Body);
+            var query = new ODataOptionOrderByExpressionVisitor().ToQuery(orderByDescending);
 
             _stringBuilder.Append($"{ODataOptionNames.OrderBy}{QuerySeparators.EqualSign}{query} {QuerySorts.Desc}{QuerySeparators.Main}");
 

--- a/src/OData.QueryBuilder/Conventions/AddressingEntities/Query/ODataQueryKey.cs
+++ b/src/OData.QueryBuilder/Conventions/AddressingEntities/Query/ODataQueryKey.cs
@@ -29,7 +29,7 @@ namespace OData.QueryBuilder.Conventions.AddressingEntities.Query
 
         public IODataQueryKey<TEntity> Expand(Expression<Func<TEntity, object>> expand)
         {
-            var query = new ODataOptionExpandExpressionVisitor().ToQuery(expand.Body);
+            var query = new ODataOptionExpandExpressionVisitor().ToQuery(expand);
 
             return Expand(query);
         }
@@ -45,7 +45,7 @@ namespace OData.QueryBuilder.Conventions.AddressingEntities.Query
 
         public IODataQueryKey<TEntity> Select(Expression<Func<TEntity, object>> select)
         {
-            var query = new ODataOptionSelectExpressionVisitor().ToQuery(select.Body);
+            var query = new ODataOptionSelectExpressionVisitor().ToQuery(select);
 
             _stringBuilder.Append($"{ODataOptionNames.Select}{QuerySeparators.EqualSign}{query}{QuerySeparators.Main}");
 

--- a/src/OData.QueryBuilder/Conventions/AddressingEntities/Resources/Expand/ODataExpandResource.cs
+++ b/src/OData.QueryBuilder/Conventions/AddressingEntities/Resources/Expand/ODataExpandResource.cs
@@ -35,7 +35,7 @@ namespace OData.QueryBuilder.Conventions.AddressingEntities.Resources.Expand
 
         public IODataQueryExpand<TNestedEntity> For<TNestedEntity>(Expression<Func<TEntity, object>> nestedExpand)
         {
-            var query = new ODataResourceExpressionVisitor().ToQuery(nestedExpand.Body);
+            var query = new ODataResourceExpressionVisitor().ToQuery(nestedExpand);
 
             if (_odataQueryExpand?.Query?.Length > 0)
             {

--- a/src/OData.QueryBuilder/Conventions/AddressingEntities/Resources/ODataResource{T}.cs
+++ b/src/OData.QueryBuilder/Conventions/AddressingEntities/Resources/ODataResource{T}.cs
@@ -24,7 +24,7 @@ namespace OData.QueryBuilder.Conventions.AddressingEntities.Resources
                 throw new ArgumentNullException(nameof(resource), "Resource name is null");
             }
 
-            var query = new ODataResourceExpressionVisitor().ToQuery(resource.Body);
+            var query = new ODataResourceExpressionVisitor().ToQuery(resource);
 
             _stringBuilder.Append(query);
 

--- a/src/OData.QueryBuilder/Conventions/Functions/ICustomFunction.cs
+++ b/src/OData.QueryBuilder/Conventions/Functions/ICustomFunction.cs
@@ -32,5 +32,12 @@ namespace OData.QueryBuilder.Conventions.Functions
         /// Replace characters
         /// </summary>
         IEnumerable<string> ReplaceCharacters(IEnumerable<string> values, IDictionary<string, string> keyValuePairs);
+
+        /// <summary>
+        /// Dynamic property
+        /// </summary>
+        /// <param name="propertyPath">The path to the property or field.</param>
+        /// <typeparam name="T">The type of the property.</typeparam>
+        T Property<T>(string propertyPath);
     }
 }

--- a/src/OData.QueryBuilder/Conventions/Functions/ICustomFunction.cs
+++ b/src/OData.QueryBuilder/Conventions/Functions/ICustomFunction.cs
@@ -32,12 +32,5 @@ namespace OData.QueryBuilder.Conventions.Functions
         /// Replace characters
         /// </summary>
         IEnumerable<string> ReplaceCharacters(IEnumerable<string> values, IDictionary<string, string> keyValuePairs);
-
-        /// <summary>
-        /// Dynamic property
-        /// </summary>
-        /// <param name="propertyPath">The path to the property or field.</param>
-        /// <typeparam name="T">The type of the property.</typeparam>
-        T Property<T>(string propertyPath);
     }
 }

--- a/src/OData.QueryBuilder/Conventions/Functions/ODataProperty.cs
+++ b/src/OData.QueryBuilder/Conventions/Functions/ODataProperty.cs
@@ -5,11 +5,11 @@ namespace OData.QueryBuilder
     public static class ODataProperty
     {
         /// <summary>
-        /// Dynamic property
+        /// Dynamically resolved a property from the OData entity.
         /// </summary>
-        /// <param name="propertyPath">The path to the property or field.</param>
-        /// <typeparam name="T">The type of the property.</typeparam>
-        public static T FromPath<T>(string propertyPath)
+        /// <param name="propertyPath">The path to the property or field using dot separation for each path component.</param>
+        /// <typeparam name="TProperty">The type of the property.</typeparam>
+        public static TProperty FromPath<TProperty>(string propertyPath)
         {
             throw new NotSupportedException("This method is only valid in OData query expressions.");
         }

--- a/src/OData.QueryBuilder/Conventions/Functions/ODataProperty.cs
+++ b/src/OData.QueryBuilder/Conventions/Functions/ODataProperty.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace OData.QueryBuilder
+{
+    public static class ODataProperty
+    {
+        /// <summary>
+        /// Dynamic property
+        /// </summary>
+        /// <param name="propertyPath">The path to the property or field.</param>
+        /// <typeparam name="T">The type of the property.</typeparam>
+        public static T FromPath<T>(string propertyPath)
+        {
+            throw new NotSupportedException("This method is only valid in OData query expressions.");
+        }
+    }
+}

--- a/src/OData.QueryBuilder/Expressions/Visitors/ODataExpressionVisitor.cs
+++ b/src/OData.QueryBuilder/Expressions/Visitors/ODataExpressionVisitor.cs
@@ -10,44 +10,44 @@ namespace OData.QueryBuilder.Expressions.Visitors
         {
         }
 
-        protected string VisitExpression(Expression expression) => expression switch
+        protected string VisitExpression(LambdaExpression topExpression, Expression expression) => expression switch
         {
-            BinaryExpression binaryExpression => VisitBinaryExpression(binaryExpression),
-            MemberExpression memberExpression => VisitMemberExpression(memberExpression),
-            ConstantExpression constantExpression => VisitConstantExpression(constantExpression),
-            MethodCallExpression methodCallExpression => VisitMethodCallExpression(methodCallExpression),
-            NewExpression newExpression => VisitNewExpression(newExpression),
-            UnaryExpression unaryExpression => VisitUnaryExpression(unaryExpression),
-            LambdaExpression lambdaExpression => VisitLambdaExpression(lambdaExpression),
-            ParameterExpression parameterExpression => VisitParameterExpression(parameterExpression),
+            BinaryExpression binaryExpression => VisitBinaryExpression(topExpression, binaryExpression),
+            MemberExpression memberExpression => VisitMemberExpression(topExpression, memberExpression),
+            ConstantExpression constantExpression => VisitConstantExpression(topExpression, constantExpression),
+            MethodCallExpression methodCallExpression => VisitMethodCallExpression(topExpression, methodCallExpression),
+            NewExpression newExpression => VisitNewExpression(topExpression, newExpression),
+            UnaryExpression unaryExpression => VisitUnaryExpression(topExpression, unaryExpression),
+            LambdaExpression lambdaExpression => VisitLambdaExpression(topExpression, lambdaExpression),
+            ParameterExpression parameterExpression => VisitParameterExpression(topExpression, parameterExpression),
             _ => default,
         };
 
         [ExcludeFromCodeCoverage]
-        protected virtual string VisitBinaryExpression(BinaryExpression binaryExpression) => default;
+        protected virtual string VisitBinaryExpression(LambdaExpression topExpression, BinaryExpression binaryExpression) => default;
 
         [ExcludeFromCodeCoverage]
-        protected virtual string VisitConstantExpression(ConstantExpression constantExpression) => default;
+        protected virtual string VisitConstantExpression(LambdaExpression topExpression, ConstantExpression constantExpression) => default;
 
         [ExcludeFromCodeCoverage]
-        protected virtual string VisitMethodCallExpression(MethodCallExpression methodCallExpression) => default;
+        protected virtual string VisitMethodCallExpression(LambdaExpression topExpression, MethodCallExpression methodCallExpression) => default;
 
         [ExcludeFromCodeCoverage]
-        protected virtual string VisitNewExpression(NewExpression newExpression) => default;
+        protected virtual string VisitNewExpression(LambdaExpression topExpression, NewExpression newExpression) => default;
 
         [ExcludeFromCodeCoverage]
-        protected virtual string VisitUnaryExpression(UnaryExpression unaryExpression) => default;
+        protected virtual string VisitUnaryExpression(LambdaExpression topExpression, UnaryExpression unaryExpression) => default;
 
         [ExcludeFromCodeCoverage]
-        protected virtual string VisitLambdaExpression(LambdaExpression lambdaExpression) => default;
+        protected virtual string VisitLambdaExpression(LambdaExpression topExpression, LambdaExpression lambdaExpression) => default;
 
         [ExcludeFromCodeCoverage]
-        protected virtual string VisitParameterExpression(ParameterExpression parameterExpression) => default;
+        protected virtual string VisitParameterExpression(LambdaExpression topExpression, ParameterExpression parameterExpression) => default;
 
         [ExcludeFromCodeCoverage]
-        protected virtual string VisitMemberExpression(MemberExpression memberExpression)
+        protected virtual string VisitMemberExpression(LambdaExpression topExpression, MemberExpression memberExpression)
         {
-            var memberName = VisitExpression(memberExpression.Expression);
+            var memberName = VisitExpression(topExpression, memberExpression.Expression);
 
             if (string.IsNullOrEmpty(memberName))
             {
@@ -60,7 +60,7 @@ namespace OData.QueryBuilder.Expressions.Visitors
                 $"{memberName}/{memberExpression.Member.Name}";
         }
 
-        public virtual string ToQuery(Expression expression) =>
-            VisitExpression(expression);
+        public virtual string ToQuery(LambdaExpression expression) =>
+            VisitExpression(expression, expression.Body);
     }
 }

--- a/src/OData.QueryBuilder/Expressions/Visitors/ODataExpressionVisitor.cs
+++ b/src/OData.QueryBuilder/Expressions/Visitors/ODataExpressionVisitor.cs
@@ -49,6 +49,11 @@ namespace OData.QueryBuilder.Expressions.Visitors
                             memberExpression = Expression.PropertyOrField(memberExpression, propertyNames[index]);
                         }
 
+                        var genericMethodType = methodCallExpression.Method.GetGenericArguments()[0];
+                        if (genericMethodType != memberExpression.Type)
+                            throw new ArgumentException(
+                                $"The type '{genericMethodType.FullName}' specified when calling 'ODataProperty.FromPath<T>(\"{propertyPath}\")' does not match the expected type '{memberExpression.Type.FullName}' defined by the model.");
+                        
                         return VisitMemberExpression(topExpression, memberExpression);
                 }
             }

--- a/src/OData.QueryBuilder/Expressions/Visitors/ODataOptionExpressionVisitor.cs
+++ b/src/OData.QueryBuilder/Expressions/Visitors/ODataOptionExpressionVisitor.cs
@@ -11,15 +11,15 @@ namespace OData.QueryBuilder.Expressions.Visitors
         {
         }
 
-        protected override string VisitUnaryExpression(UnaryExpression unaryExpression)
+        protected override string VisitUnaryExpression(LambdaExpression topExpression, UnaryExpression unaryExpression)
         {
             var odataOperator = unaryExpression.NodeType.ToODataOperator();
             var whitespace = odataOperator != default ? " " : default;
 
-            return $"{odataOperator}{whitespace}{VisitExpression(unaryExpression.Operand)}";
+            return $"{odataOperator}{whitespace}{VisitExpression(topExpression, unaryExpression.Operand)}";
         }
 
-        protected override string VisitNewExpression(NewExpression newExpression)
+        protected override string VisitNewExpression(LambdaExpression topExpression, NewExpression newExpression)
         {
             var names = new string[newExpression.Members.Count];
 

--- a/src/OData.QueryBuilder/Expressions/Visitors/ODataOptionFilterExpressionVisitor.cs
+++ b/src/OData.QueryBuilder/Expressions/Visitors/ODataOptionFilterExpressionVisitor.cs
@@ -56,182 +56,191 @@ namespace OData.QueryBuilder.Expressions.Visitors
 
         protected override string VisitMethodCallExpression(LambdaExpression topExpression, MethodCallExpression methodCallExpression)
         {
-            switch (methodCallExpression.Method.Name)
+            var declaringType = methodCallExpression.Method.DeclaringType!;
+
+            if (declaringType.IsAssignableFrom(typeof(IODataOperator)))
             {
-                case nameof(IODataOperator.In):
-                    var in0 = VisitExpression(topExpression, methodCallExpression.Arguments[0]);
-                    var in1 = _valueExpression.GetValue(methodCallExpression.Arguments[1]).ToQuery();
+                switch (methodCallExpression.Method.Name)
+                {
+                    case nameof(IODataOperator.In):
+                        var in0 = VisitExpression(topExpression, methodCallExpression.Arguments[0]);
+                        var in1 = _valueExpression.GetValue(methodCallExpression.Arguments[1]).ToQuery();
 
-                    if (in1.IsNullOrQuotes())
-                    {
-                        if (!_odataQueryBuilderOptions.SuppressExceptionOfNullOrEmptyOperatorArgs)
-                        {
-                            throw new ArgumentException("Enumeration is empty or null");
-                        }
-
-                        return default;
-                    }
-
-                    return $"{in0} {nameof(IODataOperator.In).ToLowerInvariant()} ({in1})";
-                case nameof(IODataOperator.All):
-                    var all0 = VisitExpression(topExpression, methodCallExpression.Arguments[0]);
-                    var all1 = VisitExpression(topExpression, methodCallExpression.Arguments[1]);
-
-                    return $"{all0}/{nameof(IODataOperator.All).ToLowerInvariant()}({all1})";
-                case nameof(IODataOperator.Any):
-                    var any0 = VisitExpression(topExpression, methodCallExpression.Arguments[0]);
-                    var any1 = default(string);
-
-                    if (methodCallExpression.Arguments.Count > 1)
-                    {
-                        any1 = VisitExpression(topExpression, methodCallExpression.Arguments[1]);
-
-                        if (any1.IsNullOrQuotes())
+                        if (in1.IsNullOrQuotes())
                         {
                             if (!_odataQueryBuilderOptions.SuppressExceptionOfNullOrEmptyOperatorArgs)
                             {
-                                throw new ArgumentException("Func is null");
+                                throw new ArgumentException("Enumeration is empty or null");
                             }
 
                             return default;
                         }
-                    }
 
-                    return $"{any0}/{nameof(IODataOperator.Any).ToLowerInvariant()}({any1})";
-                case nameof(IODataFunction.Date):
-                    var date0 = VisitExpression(topExpression, methodCallExpression.Arguments[0]);
+                        return $"{in0} {nameof(IODataOperator.In).ToLowerInvariant()} ({in1})";
+                    case nameof(IODataOperator.All):
+                        var all0 = VisitExpression(topExpression, methodCallExpression.Arguments[0]);
+                        var all1 = VisitExpression(topExpression, methodCallExpression.Arguments[1]);
 
-                    return $"{nameof(IODataFunction.Date).ToLowerInvariant()}({date0})";
-                case nameof(IODataFunction.SubstringOf):
-                    var substringOf0 = _valueExpression.GetValue(methodCallExpression.Arguments[0]).ToQuery();
-                    var substringOf1 = VisitExpression(topExpression, methodCallExpression.Arguments[1]);
+                        return $"{all0}/{nameof(IODataOperator.All).ToLowerInvariant()}({all1})";
+                    case nameof(IODataOperator.Any):
+                        var any0 = VisitExpression(topExpression, methodCallExpression.Arguments[0]);
+                        var any1 = default(string);
 
-                    if (substringOf0.IsNullOrQuotes())
-                    {
-                        if (!_odataQueryBuilderOptions.SuppressExceptionOfNullOrEmptyFunctionArgs)
+                        if (methodCallExpression.Arguments.Count > 1)
                         {
-                            throw new ArgumentException("Value is empty or null");
+                            any1 = VisitExpression(topExpression, methodCallExpression.Arguments[1]);
+
+                            if (any1.IsNullOrQuotes())
+                            {
+                                if (!_odataQueryBuilderOptions.SuppressExceptionOfNullOrEmptyOperatorArgs)
+                                {
+                                    throw new ArgumentException("Func is null");
+                                }
+
+                                return default;
+                            }
                         }
 
-                        return default;
-                    }
-
-                    return $"{nameof(IODataFunction.SubstringOf).ToLowerInvariant()}({substringOf0},{substringOf1})";
-                case nameof(IODataFunction.Contains):
-                    var contains0 = VisitExpression(topExpression, methodCallExpression.Arguments[0]);
-                    var contains1 = _valueExpression.GetValue(methodCallExpression.Arguments[1]).ToQuery();
-
-                    if (contains1.IsNullOrQuotes())
-                    {
-                        if (!_odataQueryBuilderOptions.SuppressExceptionOfNullOrEmptyFunctionArgs)
-                        {
-                            throw new ArgumentException("Value is empty or null");
-                        }
-
-                        return default;
-                    }
-
-                    return $"{nameof(IODataFunction.Contains).ToLowerInvariant()}({contains0},{contains1})";
-                case nameof(IODataFunction.StartsWith):
-                    var startsWith0 = VisitExpression(topExpression, methodCallExpression.Arguments[0]);
-                    var startsWith1 = _valueExpression.GetValue(methodCallExpression.Arguments[1]).ToQuery();
-
-                    if (startsWith1.IsNullOrQuotes())
-                    {
-                        if (!_odataQueryBuilderOptions.SuppressExceptionOfNullOrEmptyFunctionArgs)
-                        {
-                            throw new ArgumentException("Value is empty or null");
-                        }
-
-                        return default;
-                    }
-
-                    return $"{nameof(IODataFunction.StartsWith).ToLowerInvariant()}({startsWith0},{startsWith1})";
-                case nameof(IODataFunction.Concat):
-                    var concat0 = VisitExpression(topExpression, methodCallExpression.Arguments[0]);
-                    var concat1 = VisitExpression(topExpression, methodCallExpression.Arguments[1]);
-
-                    if (concat0.IsNullOrQuotes() || concat1.IsNullOrQuotes())
-                    {
-                        if (!_odataQueryBuilderOptions.SuppressExceptionOfNullOrEmptyFunctionArgs)
-                        {
-                            throw new ArgumentException("Value is empty or null");
-                        }
-
-                        return default;
-                    }
-
-                    return $"{nameof(IODataFunction.Concat).ToLowerInvariant()}({concat0},{concat1})";
-                case nameof(IODataStringAndCollectionFunction.ToUpper):
-                    var toUpper0 = VisitExpression(topExpression, methodCallExpression.Arguments[0]);
-
-                    return $"{nameof(IODataFunction.ToUpper).ToLowerInvariant()}({toUpper0})";
-                case nameof(IODataStringAndCollectionFunction.ToLower):
-                    var toLower0 = VisitExpression(topExpression, methodCallExpression.Arguments[0]);
-
-                    return $"{nameof(IODataFunction.ToLower).ToLowerInvariant()}({toLower0})";
-                case nameof(IODataStringAndCollectionFunction.IndexOf):
-                    var indexOf0 = VisitExpression(topExpression, methodCallExpression.Arguments[0]);
-                    var indexOf1 = VisitExpression(topExpression, methodCallExpression.Arguments[1]);
-
-                    return $"{nameof(IODataFunction.IndexOf).ToLowerInvariant()}({indexOf0},{indexOf1})";
-                case nameof(IODataStringAndCollectionFunction.Length):
-                    var length0 = VisitExpression(topExpression, methodCallExpression.Arguments[0]);
-
-                    return $"{nameof(IODataStringAndCollectionFunction.Length).ToLowerInvariant()}({length0})";
-                case nameof(ICustomFunction.ConvertEnumToString):
-                    return $"'{_valueExpression.GetValue(methodCallExpression.Arguments[0])}'";
-                case nameof(ICustomFunction.ConvertDateTimeToString):
-                    var dateTime = (DateTime)_valueExpression.GetValue(methodCallExpression.Arguments[0]);
-
-                    return dateTime.ToString((string)_valueExpression.GetValue(methodCallExpression.Arguments[1]));
-                case nameof(ICustomFunction.ConvertDateTimeOffsetToString):
-                    var dateTimeOffset = (DateTimeOffset)_valueExpression.GetValue(methodCallExpression.Arguments[0]);
-
-                    return dateTimeOffset.ToString((string)_valueExpression.GetValue(methodCallExpression.Arguments[1]));
-                case nameof(ICustomFunction.ReplaceCharacters):
-                    var @symbol0 = _valueExpression.GetValue(methodCallExpression.Arguments[0]).ToQuery();
-                    var @symbol1 = _valueExpression.GetValue(methodCallExpression.Arguments[1]);
-
-                    if (@symbol1 == default)
-                    {
-                        throw new ArgumentException("KeyValuePairs is null");
-                    }
-
-                    return @symbol0.ReplaceWithStringBuilder(@symbol1 as IDictionary<string, string>);
-                case nameof(ICustomFunction.Property):
-                    string propertyPath = (string) _valueExpression.GetValue(methodCallExpression.Arguments[0]);
-                    var propertyNames = propertyPath.Split('.');
-
-                    MemberExpression memberExpression = Expression.PropertyOrField(
-                        Expression.Parameter(topExpression.Parameters[0].Type, "m"),
-                        propertyNames[0]);
-                
-                    for (var index = 1; index < propertyNames.Length; index++)
-                    {
-                        memberExpression = Expression.PropertyOrField(memberExpression, propertyNames[index]);
-                    }
-                    return VisitMemberExpression(topExpression, memberExpression);
-                case nameof(ITypeFunction.Cast):
-                    var cast0 = VisitExpression(topExpression, methodCallExpression.Arguments[0]);
-                    var cast1 = _valueExpression.GetValue(methodCallExpression.Arguments[1]) as string;
-
-                    if (string.IsNullOrEmpty(cast1))
-                    {
-                        if (!_odataQueryBuilderOptions.SuppressExceptionOfNullOrEmptyFunctionArgs)
-                        {
-                            throw new ArgumentException("Type is empty or null");
-                        }
-
-                        return default;
-                    }
-
-                    return $"{nameof(ITypeFunction.Cast).ToLowerInvariant()}({cast0},{cast1})";
-                case nameof(string.ToString):
-                    return _valueExpression.GetValue(methodCallExpression.Object).ToString().ToQuery();
-                default:
-                    throw new NotSupportedException($"Method {methodCallExpression.Method.Name} not supported");
+                        return $"{any0}/{nameof(IODataOperator.Any).ToLowerInvariant()}({any1})";
+                }
             }
+            
+            if (declaringType.IsAssignableFrom(typeof(IODataFunction)))
+            {
+                switch (methodCallExpression.Method.Name)
+                {
+                    case nameof(IODataFunction.Date):
+                        var date0 = VisitExpression(topExpression, methodCallExpression.Arguments[0]);
+
+                        return $"{nameof(IODataFunction.Date).ToLowerInvariant()}({date0})";
+                    case nameof(IODataFunction.SubstringOf):
+                        var substringOf0 = _valueExpression.GetValue(methodCallExpression.Arguments[0]).ToQuery();
+                        var substringOf1 = VisitExpression(topExpression, methodCallExpression.Arguments[1]);
+
+                        if (substringOf0.IsNullOrQuotes())
+                        {
+                            if (!_odataQueryBuilderOptions.SuppressExceptionOfNullOrEmptyFunctionArgs)
+                            {
+                                throw new ArgumentException("Value is empty or null");
+                            }
+
+                            return default;
+                        }
+
+                        return
+                            $"{nameof(IODataFunction.SubstringOf).ToLowerInvariant()}({substringOf0},{substringOf1})";
+                    case nameof(IODataFunction.Contains):
+                        var contains0 = VisitExpression(topExpression, methodCallExpression.Arguments[0]);
+                        var contains1 = _valueExpression.GetValue(methodCallExpression.Arguments[1]).ToQuery();
+
+                        if (contains1.IsNullOrQuotes())
+                        {
+                            if (!_odataQueryBuilderOptions.SuppressExceptionOfNullOrEmptyFunctionArgs)
+                            {
+                                throw new ArgumentException("Value is empty or null");
+                            }
+
+                            return default;
+                        }
+
+                        return $"{nameof(IODataFunction.Contains).ToLowerInvariant()}({contains0},{contains1})";
+                    case nameof(IODataFunction.StartsWith):
+                        var startsWith0 = VisitExpression(topExpression, methodCallExpression.Arguments[0]);
+                        var startsWith1 = _valueExpression.GetValue(methodCallExpression.Arguments[1]).ToQuery();
+
+                        if (startsWith1.IsNullOrQuotes())
+                        {
+                            if (!_odataQueryBuilderOptions.SuppressExceptionOfNullOrEmptyFunctionArgs)
+                            {
+                                throw new ArgumentException("Value is empty or null");
+                            }
+
+                            return default;
+                        }
+
+                        return $"{nameof(IODataFunction.StartsWith).ToLowerInvariant()}({startsWith0},{startsWith1})";
+                    case nameof(IODataFunction.Concat):
+                        var concat0 = VisitExpression(topExpression, methodCallExpression.Arguments[0]);
+                        var concat1 = VisitExpression(topExpression, methodCallExpression.Arguments[1]);
+
+                        if (concat0.IsNullOrQuotes() || concat1.IsNullOrQuotes())
+                        {
+                            if (!_odataQueryBuilderOptions.SuppressExceptionOfNullOrEmptyFunctionArgs)
+                            {
+                                throw new ArgumentException("Value is empty or null");
+                            }
+
+                            return default;
+                        }
+
+                        return $"{nameof(IODataFunction.Concat).ToLowerInvariant()}({concat0},{concat1})";
+                    case nameof(IODataStringAndCollectionFunction.ToUpper):
+                        var toUpper0 = VisitExpression(topExpression, methodCallExpression.Arguments[0]);
+
+                        return $"{nameof(IODataFunction.ToUpper).ToLowerInvariant()}({toUpper0})";
+                    case nameof(IODataStringAndCollectionFunction.ToLower):
+                        var toLower0 = VisitExpression(topExpression, methodCallExpression.Arguments[0]);
+
+                        return $"{nameof(IODataFunction.ToLower).ToLowerInvariant()}({toLower0})";
+                    case nameof(IODataStringAndCollectionFunction.IndexOf):
+                        var indexOf0 = VisitExpression(topExpression, methodCallExpression.Arguments[0]);
+                        var indexOf1 = VisitExpression(topExpression, methodCallExpression.Arguments[1]);
+
+                        return $"{nameof(IODataFunction.IndexOf).ToLowerInvariant()}({indexOf0},{indexOf1})";
+                    case nameof(IODataStringAndCollectionFunction.Length):
+                        var length0 = VisitExpression(topExpression, methodCallExpression.Arguments[0]);
+
+                        return $"{nameof(IODataStringAndCollectionFunction.Length).ToLowerInvariant()}({length0})";
+                    case nameof(ICustomFunction.ConvertEnumToString):
+                        return $"'{_valueExpression.GetValue(methodCallExpression.Arguments[0])}'";
+                    case nameof(ICustomFunction.ConvertDateTimeToString):
+                        var dateTime = (DateTime)_valueExpression.GetValue(methodCallExpression.Arguments[0]);
+
+                        return dateTime.ToString((string)_valueExpression.GetValue(methodCallExpression.Arguments[1]));
+                    case nameof(ICustomFunction.ConvertDateTimeOffsetToString):
+                        var dateTimeOffset =
+                            (DateTimeOffset)_valueExpression.GetValue(methodCallExpression.Arguments[0]);
+
+                        return dateTimeOffset.ToString(
+                            (string)_valueExpression.GetValue(methodCallExpression.Arguments[1]));
+                    case nameof(ICustomFunction.ReplaceCharacters):
+                        var @symbol0 = _valueExpression.GetValue(methodCallExpression.Arguments[0]).ToQuery();
+                        var @symbol1 = _valueExpression.GetValue(methodCallExpression.Arguments[1]);
+
+                        if (@symbol1 == default)
+                        {
+                            throw new ArgumentException("KeyValuePairs is null");
+                        }
+
+                        return @symbol0.ReplaceWithStringBuilder(@symbol1 as IDictionary<string, string>);
+                    case nameof(ITypeFunction.Cast):
+                        var cast0 = VisitExpression(topExpression, methodCallExpression.Arguments[0]);
+                        var cast1 = _valueExpression.GetValue(methodCallExpression.Arguments[1]) as string;
+
+                        if (string.IsNullOrEmpty(cast1))
+                        {
+                            if (!_odataQueryBuilderOptions.SuppressExceptionOfNullOrEmptyFunctionArgs)
+                            {
+                                throw new ArgumentException("Type is empty or null");
+                            }
+
+                            return default;
+                        }
+
+                        return $"{nameof(ITypeFunction.Cast).ToLowerInvariant()}({cast0},{cast1})";
+                }
+            }
+
+            if (typeof(object).IsAssignableFrom(declaringType))
+            {
+                switch (methodCallExpression.Method.Name)
+                {
+                    case nameof(object.ToString):
+                        return _valueExpression.GetValue(methodCallExpression.Object).ToString().ToQuery();
+                }
+            }
+
+            return base.VisitMethodCallExpression(topExpression, methodCallExpression);
         }
 
         protected override string VisitNewExpression(LambdaExpression topExpression, NewExpression newExpression)

--- a/src/OData.QueryBuilder/Expressions/Visitors/ODataOptionFilterLambdaExpressionVisitor.cs
+++ b/src/OData.QueryBuilder/Expressions/Visitors/ODataOptionFilterLambdaExpressionVisitor.cs
@@ -1,4 +1,5 @@
-﻿using OData.QueryBuilder.Options;
+﻿using System;
+using OData.QueryBuilder.Options;
 using System.Linq.Expressions;
 
 namespace OData.QueryBuilder.Expressions.Visitors
@@ -10,7 +11,7 @@ namespace OData.QueryBuilder.Expressions.Visitors
         {
         }
 
-        protected override string VisitParameterExpression(ParameterExpression parameterExpression) =>
+        protected override string VisitParameterExpression(LambdaExpression topExpression, ParameterExpression parameterExpression) =>
             parameterExpression.Name;
     }
 }

--- a/src/OData.QueryBuilder/Expressions/Visitors/ODataOptionOrderByExpressionVisitor.cs
+++ b/src/OData.QueryBuilder/Expressions/Visitors/ODataOptionOrderByExpressionVisitor.cs
@@ -14,25 +14,33 @@ namespace OData.QueryBuilder.Expressions.Visitors
 
         protected override string VisitMethodCallExpression(LambdaExpression topExpression, MethodCallExpression methodCallExpression)
         {
-            switch (methodCallExpression.Method.Name)
+            var method = methodCallExpression.Method;
+            if (method.DeclaringType!.IsAssignableFrom(typeof(ISortFunction)))
             {
-                case nameof(ISortFunction.Ascending):
-                    var ascending0 = VisitExpression(topExpression, methodCallExpression.Arguments[0]);
+                switch (method.Name)
+                {
+                    case nameof(ISortFunction.Ascending):
+                        var ascending0 = VisitExpression(topExpression, methodCallExpression.Arguments[0]);
 
-                    var ascendingQuery = VisitExpression(topExpression, methodCallExpression.Object as MethodCallExpression);
-                    var ascendingQueryComma = ascendingQuery == default ? string.Empty : QuerySeparators.StringComma;
+                        var ascendingQuery = VisitExpression(topExpression,
+                            methodCallExpression.Object as MethodCallExpression);
+                        var ascendingQueryComma =
+                            ascendingQuery == default ? string.Empty : QuerySeparators.StringComma;
 
-                    return $"{ascendingQuery}{ascendingQueryComma}{ascending0} {QuerySorts.Asc}";
-                case nameof(ISortFunction.Descending):
-                    var descending0 = VisitExpression(topExpression, methodCallExpression.Arguments[0]);
+                        return $"{ascendingQuery}{ascendingQueryComma}{ascending0} {QuerySorts.Asc}";
+                    case nameof(ISortFunction.Descending):
+                        var descending0 = VisitExpression(topExpression, methodCallExpression.Arguments[0]);
 
-                    var descendingQuery = VisitExpression(topExpression, methodCallExpression.Object as MethodCallExpression);
-                    var descendingQueryComma = descendingQuery == default ? string.Empty : QuerySeparators.StringComma;
+                        var descendingQuery = VisitExpression(topExpression,
+                            methodCallExpression.Object as MethodCallExpression);
+                        var descendingQueryComma =
+                            descendingQuery == default ? string.Empty : QuerySeparators.StringComma;
 
-                    return $"{descendingQuery}{descendingQueryComma}{descending0} {QuerySorts.Desc}";
-                default:
-                    throw new NotSupportedException($"Method {methodCallExpression.Method.Name} not supported");
+                        return $"{descendingQuery}{descendingQueryComma}{descending0} {QuerySorts.Desc}";
+                }
             }
+
+            return base.VisitMethodCallExpression(topExpression, methodCallExpression);
         }
     }
 }

--- a/src/OData.QueryBuilder/Expressions/Visitors/ODataOptionOrderByExpressionVisitor.cs
+++ b/src/OData.QueryBuilder/Expressions/Visitors/ODataOptionOrderByExpressionVisitor.cs
@@ -12,21 +12,21 @@ namespace OData.QueryBuilder.Expressions.Visitors
         {
         }
 
-        protected override string VisitMethodCallExpression(MethodCallExpression methodCallExpression)
+        protected override string VisitMethodCallExpression(LambdaExpression topExpression, MethodCallExpression methodCallExpression)
         {
             switch (methodCallExpression.Method.Name)
             {
                 case nameof(ISortFunction.Ascending):
-                    var ascending0 = VisitExpression(methodCallExpression.Arguments[0]);
+                    var ascending0 = VisitExpression(topExpression, methodCallExpression.Arguments[0]);
 
-                    var ascendingQuery = VisitExpression(methodCallExpression.Object as MethodCallExpression);
+                    var ascendingQuery = VisitExpression(topExpression, methodCallExpression.Object as MethodCallExpression);
                     var ascendingQueryComma = ascendingQuery == default ? string.Empty : QuerySeparators.StringComma;
 
                     return $"{ascendingQuery}{ascendingQueryComma}{ascending0} {QuerySorts.Asc}";
                 case nameof(ISortFunction.Descending):
-                    var descending0 = VisitExpression(methodCallExpression.Arguments[0]);
+                    var descending0 = VisitExpression(topExpression, methodCallExpression.Arguments[0]);
 
-                    var descendingQuery = VisitExpression(methodCallExpression.Object as MethodCallExpression);
+                    var descendingQuery = VisitExpression(topExpression, methodCallExpression.Object as MethodCallExpression);
                     var descendingQueryComma = descendingQuery == default ? string.Empty : QuerySeparators.StringComma;
 
                     return $"{descendingQuery}{descendingQueryComma}{descending0} {QuerySorts.Desc}";

--- a/test/OData.QueryBuilder.Test/ODataQueryCollectionTest.cs
+++ b/test/OData.QueryBuilder.Test/ODataQueryCollectionTest.cs
@@ -315,6 +315,32 @@ namespace OData.QueryBuilder.Test
                 .Should().Throw<ArgumentException>().WithMessage("KeyValuePairs is null");
         }
 
+        [Fact(DisplayName = "Filter variable dynamic property int=> Success")]
+        public void ODataQueryBuilderList_Filter_Simple_Variable_DynamicProperty_Success()
+        {
+            string propertyName = "ODataKind.ODataCode.IdCode";
+            
+            var uri = _odataQueryBuilderDefault
+                .For<ODataTypeEntity>(s => s.ODataType)
+                .ByList()
+                .Filter((s,f,_) => f.Property<int>(propertyName) >= 3)
+                .ToUri();
+
+            uri.Should().Be("http://mock/odata/ODataType?$filter=ODataKind/ODataCode/IdCode ge 3");
+        }
+
+        [Fact(DisplayName = "Filter const dynamic property int=> Success")]
+        public void ODataQueryBuilderList_Filter_Simple_Const_DynamicProperty_Success()
+        {
+            var uri = _odataQueryBuilderDefault
+                .For<ODataTypeEntity>(s => s.ODataType)
+                .ByList()
+                .Filter((s,f,_) => f.Property<int>("ODataKind.ODataCode.IdCode") >= 3)
+                .ToUri();
+
+            uri.Should().Be("http://mock/odata/ODataType?$filter=ODataKind/ODataCode/IdCode ge 3");
+        }
+        
         [Fact(DisplayName = "Filter simple const int=> Success")]
         public void ODataQueryBuilderList_Filter_Simple_Const_Int_Success()
         {
@@ -362,6 +388,18 @@ namespace OData.QueryBuilder.Test
                 .For<ODataTypeEntity>(s => s.ODataType)
                 .ByList()
                 .Filter((s, f, o) => o.Any(s.Tags, t => t == "testTag"))
+                .ToUri();
+
+            uri.Should().Be("http://mock/odata/ODataType?$filter=Tags/any(t:t eq 'testTag')");
+        }
+
+        [Fact(DisplayName = "(ODataQueryBuilderList) Filter Any Dynamic property => Success")]
+        public void ODataQueryBuilderList_Filter_Any_DynamicProperty_Success()
+        {
+            var uri = _odataQueryBuilderDefault
+                .For<ODataTypeEntity>(s => s.ODataType)
+                .ByList()
+                .Filter((s, f, o) => o.Any(f.Property<string[]>("Tags"), t => t == "testTag"))
                 .ToUri();
 
             uri.Should().Be("http://mock/odata/ODataType?$filter=Tags/any(t:t eq 'testTag')");

--- a/test/OData.QueryBuilder.Test/ODataQueryCollectionTest.cs
+++ b/test/OData.QueryBuilder.Test/ODataQueryCollectionTest.cs
@@ -35,6 +35,18 @@ namespace OData.QueryBuilder.Test
             uri.Should().Be("http://mock/odata/ODataType?$expand=ODataKind");
         }
 
+        [Fact(DisplayName = "Expand dynamic property => Success")]
+        public void ODataQueryBuilderList_Expand_DynamicProperty_Success()
+        {
+            var uri = _odataQueryBuilderDefault
+                .For<ODataTypeEntity>(s => s.ODataType)
+                .ByList()
+                .Expand(s => new { ODataKind = ODataProperty.FromPath<ODataKindEntity>("ODataKind") })
+                .ToUri();
+
+            uri.Should().Be("http://mock/odata/ODataType?$expand=ODataKind");
+        }
+        
         [Fact(DisplayName = "Select simple => Success")]
         public void ODataQueryBuilderList_Select_Simple_Success()
         {
@@ -47,6 +59,18 @@ namespace OData.QueryBuilder.Test
             uri.Should().Be("http://mock/odata/ODataType?$select=IdType");
         }
 
+        [Fact(DisplayName = "Select dynamic property => Success")]
+        public void ODataQueryBuilderList_Select_DynamicProperty_Success()
+        {
+            var uri = _odataQueryBuilderDefault
+                .For<ODataTypeEntity>(s => s.ODataType)
+                .ByList()
+                .Select(s => ODataProperty.FromPath<int>("IdType"))
+                .ToUri();
+
+            uri.Should().Be("http://mock/odata/ODataType?$select=IdType");
+        }
+        
         [Fact(DisplayName = "OrderBy simple => Success")]
         public void ODataQueryBuilderList_OrderBy_Simple_Success()
         {
@@ -59,6 +83,18 @@ namespace OData.QueryBuilder.Test
             uri.Should().Be("http://mock/odata/ODataType?$orderby=IdType asc");
         }
 
+        [Fact(DisplayName = "OrderBy dynamic property => Success")]
+        public void ODataQueryBuilderList_OrderBy_DynamicProperty_Success()
+        {
+            var uri = _odataQueryBuilderDefault
+                .For<ODataTypeEntity>(s => s.ODataType)
+                .ByList()
+                .OrderBy(s => ODataProperty.FromPath<int>("IdType"))
+                .ToUri();
+
+            uri.Should().Be("http://mock/odata/ODataType?$orderby=IdType asc");
+        }
+        
         [Fact(DisplayName = "Filter orderBy multiple sort => Success")]
         public void ODataQueryBuilderList_Filter_OrderBy_Multiple_Sort_Success()
         {
@@ -323,7 +359,7 @@ namespace OData.QueryBuilder.Test
             var uri = _odataQueryBuilderDefault
                 .For<ODataTypeEntity>(s => s.ODataType)
                 .ByList()
-                .Filter((s,f,_) => f.Property<int>(propertyName) >= 3)
+                .Filter((s,f,_) => ODataProperty.FromPath<int>(propertyName) >= 3)
                 .ToUri();
 
             uri.Should().Be("http://mock/odata/ODataType?$filter=ODataKind/ODataCode/IdCode ge 3");
@@ -335,7 +371,7 @@ namespace OData.QueryBuilder.Test
             var uri = _odataQueryBuilderDefault
                 .For<ODataTypeEntity>(s => s.ODataType)
                 .ByList()
-                .Filter((s,f,_) => f.Property<int>("ODataKind.ODataCode.IdCode") >= 3)
+                .Filter((s,f,_) => ODataProperty.FromPath<int>("ODataKind.ODataCode.IdCode") >= 3)
                 .ToUri();
 
             uri.Should().Be("http://mock/odata/ODataType?$filter=ODataKind/ODataCode/IdCode ge 3");
@@ -399,7 +435,7 @@ namespace OData.QueryBuilder.Test
             var uri = _odataQueryBuilderDefault
                 .For<ODataTypeEntity>(s => s.ODataType)
                 .ByList()
-                .Filter((s, f, o) => o.Any(f.Property<string[]>("Tags"), t => t == "testTag"))
+                .Filter((s, f, o) => o.Any(ODataProperty.FromPath<string[]>("Tags"), t => t == "testTag"))
                 .ToUri();
 
             uri.Should().Be("http://mock/odata/ODataType?$filter=Tags/any(t:t eq 'testTag')");

--- a/test/OData.QueryBuilder.Test/ODataQueryCollectionTest.cs
+++ b/test/OData.QueryBuilder.Test/ODataQueryCollectionTest.cs
@@ -365,6 +365,19 @@ namespace OData.QueryBuilder.Test
             uri.Should().Be("http://mock/odata/ODataType?$filter=ODataKind/ODataCode/IdCode ge 3");
         }
 
+        [Fact(DisplayName = "Filter variable dynamic property wrong type => ArgumentException")]
+        public void ODataQueryBuilderList_Filter_Simple_Variable_DynamicProperty_WrongType_ArgumentException()
+        {
+            string propertyName = "ODataKind.ODataCode.IdCode";
+
+            var uri = _odataQueryBuilderDefault
+                .Invoking(b => b
+                    .For<ODataTypeEntity>(s => s.ODataType)
+                    .ByList()
+                    .Filter((s, f, _) => ODataProperty.FromPath<string>(propertyName) == "test")
+                    .ToUri()).Should().Throw<ArgumentException>();
+        }
+        
         [Fact(DisplayName = "Filter const dynamic property int=> Success")]
         public void ODataQueryBuilderList_Filter_Simple_Const_DynamicProperty_Success()
         {


### PR DESCRIPTION
Implements #101 

I guess the solution with a `Property` method defined in the `ICustomFunction` interface is not really appropriate as it would not allow to use dynamic properties in calls to `Select`, `Expand` and `OrderBy`.

I could rework the PR and introduce a static stub method like mentioned in the feature request.

So instead of having a `ICustomFunction.Property<T>(string propertyPath)` method I would introduce a `ODataProperty.OfType<T>(string propertyPath)` method.

What do you think @ZEXSM ? 
