### PR TITLE
Support reusing Expressions between filters on the expand level and any/all conditions on the root level.

### DIFF
--- a/src/OData.QueryBuilder/Conventions/Operators/IODataOperator.cs
+++ b/src/OData.QueryBuilder/Conventions/Operators/IODataOperator.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq.Expressions;
 
 namespace OData.QueryBuilder.Conventions.Operators
 {
@@ -7,10 +8,10 @@ namespace OData.QueryBuilder.Conventions.Operators
     {
         bool In<T>(T columnName, IEnumerable<T> values);
 
-        bool All<T>(IEnumerable<T> columnName, Func<T, bool> func);
+        bool All<T>(IEnumerable<T> columnName, Expression<Func<T, bool>> func);
 
         bool Any<T>(IEnumerable<T> columnName);
-
-        bool Any<T>(IEnumerable<T> columnName, Func<T, bool> func);
+        
+        bool Any<T>(IEnumerable<T> columnName, Expression<Func<T, bool>> func);
     }
 }

--- a/src/OData.QueryBuilder/Expressions/Visitors/ODataOptionFilterExpressionVisitor.cs
+++ b/src/OData.QueryBuilder/Expressions/Visitors/ODataOptionFilterExpressionVisitor.cs
@@ -46,11 +46,21 @@ namespace OData.QueryBuilder.Expressions.Visitors
                 :
                 $"{left} {binaryExpression.NodeType.ToODataOperator()} {right}";
         }
-
-        protected override string VisitMemberExpression(LambdaExpression topExpression, MemberExpression memberExpression) =>
-            IsMemberExpressionBelongsResource(memberExpression)
-            ? base.VisitMemberExpression(topExpression, memberExpression)
-            : _valueExpression.GetValue(memberExpression).ToQuery(_odataQueryBuilderOptions);
+        
+        protected override string VisitMemberExpression(LambdaExpression topExpression, MemberExpression memberExpression)
+        {
+            if (IsMemberExpressionBelongsResource(memberExpression))
+            {
+                return base.VisitMemberExpression(topExpression, memberExpression);
+            }
+            
+            var value = _valueExpression.GetValue(memberExpression);
+            if (value is Expression expression)
+            {
+                return VisitExpression(topExpression, expression);
+            }
+            return value.ToQuery(_odataQueryBuilderOptions);
+        }
 
         protected override string VisitConstantExpression(LambdaExpression topExpression, ConstantExpression constantExpression) =>
             constantExpression.Value.ToQuery(_odataQueryBuilderOptions);


### PR DESCRIPTION
fixes ZEXSM/OData.QueryBuilder#123

Possible breaking:
Changed the All and Any methods to take Expression<Func<T, bool>> instead of Func<T, bool>. As far as I can tell this does not impact anything since explicitly passing a non-null Func<T, bool> previously was unsupported.

Unsure what caused the whitespace changes, LMK if you want me to fix it